### PR TITLE
Set the effective block size to None in the default config, fix log message

### DIFF
--- a/conf/dataset/nlp/language_modeling/default.yaml
+++ b/conf/dataset/nlp/language_modeling/default.yaml
@@ -2,3 +2,5 @@
 defaults:
   - nlp/default
 _target_: lightning_transformers.task.nlp.language_modeling.LanguageModelingDataModule
+cfg:
+  block_size: null

--- a/lightning_transformers/task/nlp/language_modeling/data.py
+++ b/lightning_transformers/task/nlp/language_modeling/data.py
@@ -70,7 +70,7 @@ class LanguageModelingDataModule(HFDataModule):
                 log.warn(
                     f"The tokenizer picked seems to have a very large `model_max_length` "
                     f"({self.tokenizer.model_max_length}). "
-                    "Picking 1024 instead. You can change that default value by passing --block_size xxx."
+                    "Picking 1024 instead. You can change that default value by passing dataset.cfg.block_size=x."
                 )
             block_size = 1024
         else:


### PR DESCRIPTION
Should fix #159 