### PR TITLE
Set correct plugin for deepspeed general trainer config

### DIFF
--- a/conf/trainer/deepspeed.yaml
+++ b/conf/trainer/deepspeed.yaml
@@ -1,5 +1,5 @@
 defaults:
   - ddp # inherit from ddp trainer conf
-  - plugins: zero_offload
+  - plugins: deepspeed
 accelerator: ddp
 precision: 16


### PR DESCRIPTION
Closes #161 

I may remove this in the future to suggest people to use directly the plugins, as this is just additional complication, and same with the sharded.yaml.