### PR TITLE
Set DDP As default, allowing trainer.gpus=2 without specifying ddp

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ tokenizer:
 python train.py \
     task=nlp/text_classification \
     dataset=nlp/text_classification/emotion \
-    trainer/plugins=sharded
+    trainer=sharded
 ```
 
 <details>
@@ -247,8 +247,6 @@ trainer:
    tpu_cores: null
    log_gpu_memory: null
    ...
-   val_check_interval: 1.0
-   flush_logs_every_n_steps: 100
    log_every_n_steps: 50
 -  accelerator: null
 +  accelerator: ddp
@@ -256,8 +254,6 @@ trainer:
 -  precision: 32
 +  precision: 16
    weights_summary: top
-   weights_save_path: null
-   num_sanity_val_steps: 2
    ....
    terminate_on_nan: false
    auto_scale_batch_size: false
@@ -282,8 +278,7 @@ tokenizer:
 python train.py \
     task=nlp/text_classification \
     dataset=nlp/text_classification/emotion \
-    trainer=ddp \
-    trainer/plugins=deepspeed
+    trainer=deepspeed
 ```
 
 <details>

--- a/README.md
+++ b/README.md
@@ -226,7 +226,6 @@ tokenizer:
 python train.py \
     task=nlp/text_classification \
     dataset=nlp/text_classification/emotion \
-    trainer=ddp \
     trainer/plugins=sharded
 ```
 

--- a/conf/trainer/ddp.yaml
+++ b/conf/trainer/ddp.yaml
@@ -1,4 +1,0 @@
-defaults:
-  - default # add args from default trainer conf
-gpus: 1
-accelerator: ddp

--- a/conf/trainer/default.yaml
+++ b/conf/trainer/default.yaml
@@ -27,7 +27,7 @@ limit_test_batches: 1.0
 val_check_interval: 1.0
 flush_logs_every_n_steps: 100
 log_every_n_steps: 50
-accelerator: null
+accelerator: ddp
 sync_batchnorm: False
 precision: 32
 weights_summary: 'top'


### PR DESCRIPTION
Fixes #147 

This does bring up the issue of no multi-gpu support within notebooks, however given the intricacies of the scheduler I'd rather have this fix, till there is demand.