### PR TITLE
Reflect default settings changed to using ddp

### DIFF
--- a/conf/trainer/deepspeed.yaml
+++ b/conf/trainer/deepspeed.yaml
@@ -1,5 +1,5 @@
 defaults:
-  - ddp # inherit from ddp trainer conf
+  - default # inherit from default trainer conf
   - plugins: deepspeed
 accelerator: ddp
 precision: 16

--- a/conf/trainer/sharded.yaml
+++ b/conf/trainer/sharded.yaml
@@ -1,5 +1,5 @@
 defaults:
-  - ddp # inherit from ddp trainer conf
+  - default # inherit from default trainer conf
   - plugins: sharded
 accelerator: ddp
 precision: 16


### PR DESCRIPTION
Thank you for the very good repository.

The default configuration has been updated recently. Because there is no ddp anymore, an error is occurring when deepspeed and sharded are selected among the trainers.

we proceeded with a simple correction.