### PR TITLE
Disable minimal tests for windows CI

### DIFF
--- a/.github/workflows/ci_testing.yml
+++ b/.github/workflows/ci_testing.yml
@@ -16,6 +16,10 @@ jobs:
         os: [ubuntu-20.04, macOS-10.15, windows-2019]
         python-version: [3.6, 3.8]
         requires: ['minimal', 'latest']
+        exclude:
+          # excludes windows minimal test as HF hanging
+          - os: windows-2019
+            requires: 'minimal'
 
     # Timeout: https://stackoverflow.com/a/59076067/4521646
     timeout-minutes: 35

--- a/.github/workflows/ci_testing.yml
+++ b/.github/workflows/ci_testing.yml
@@ -39,7 +39,12 @@ jobs:
         python -c "fpath = 'requirements.txt' ; req = open(fpath).read().replace('>=', '==') ; open(fpath, 'w').write(req)"
         python -c "fpath = 'requirements/test.txt' ; req = open(fpath).read().replace('>=', '==') ; open(fpath, 'w').write(req)"
 
-    # Note: This uses an internal pip API and may not always work
+    - name: Install latest PyTorch for Windows
+      if: matrix.requires == 'minimal' and runner.os == 'windows'
+      run: |
+        pip install torch -U
+
+      # Note: This uses an internal pip API and may not always work
     # https://github.com/actions/cache/blob/master/examples.md#multiple-oss-in-a-workflow
     - name: Get pip cache
       id: pip-cache

--- a/.github/workflows/ci_testing.yml
+++ b/.github/workflows/ci_testing.yml
@@ -39,12 +39,7 @@ jobs:
         python -c "fpath = 'requirements.txt' ; req = open(fpath).read().replace('>=', '==') ; open(fpath, 'w').write(req)"
         python -c "fpath = 'requirements/test.txt' ; req = open(fpath).read().replace('>=', '==') ; open(fpath, 'w').write(req)"
 
-    - name: Install latest PyTorch for Windows
-      if: matrix.requires == 'minimal' and runner.os == 'windows'
-      run: |
-        pip install torch -U
-
-      # Note: This uses an internal pip API and may not always work
+    # Note: This uses an internal pip API and may not always work
     # https://github.com/actions/cache/blob/master/examples.md#multiple-oss-in-a-workflow
     - name: Get pip cache
       id: pip-cache

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 pytorch-lightning>=1.4.0
-torch>=1.7.1
+torch>=1.9.1
 numpy
 tqdm
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 pytorch-lightning>=1.4.0
-torch>=1.6
+torch>=1.7.1
 numpy
 tqdm
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 pytorch-lightning>=1.4.0
-torch>=1.9.1
+torch>=1.7.1
 numpy
 tqdm
 


### PR DESCRIPTION
Windows Minimal tests are hanging, and rather than completely skipping the tests I've opted for removing the minimal configuration for windows to still completely test latest. I've also made latest the required test for windows.