### PR TITLE
Drop AMP level

### DIFF
--- a/conf/trainer/default.yaml
+++ b/conf/trainer/default.yaml
@@ -45,5 +45,4 @@ auto_scale_batch_size: False
 prepare_data_per_node: True
 plugins: null
 amp_backend: 'native'
-amp_level: 'O2'
 move_metrics_to_cpu: False


### PR DESCRIPTION
Dropping AMP level as on lightning master it seems to be a pretty strict check if set to anything other than None.