### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,9 @@ dm = TextClassificationDataModule(
     ),
     tokenizer=tokenizer,
 )
-model = TextClassificationTransformer(pretrained_model_name_or_path="bert-base-cased")
+model = TextClassificationTransformer(
+    pretrained_model_name_or_path="bert-base-cased", num_labels=dm.num_classes
+)
 
 trainer = pl.Trainer(accelerator="auto", devices="auto", max_epochs=1)
 


### PR DESCRIPTION
Hi @SeanNaren,
In 1994d03c4953cd97bcf35f3c172cc2abb423b387, the argument `num_labels` of `TextClassificationTransformer` in the text classification example in README has been deleted. However, the "emotion" is a multiple emotions dataset.